### PR TITLE
Disassociate artifacts related at wizard to delete

### DIFF
--- a/src/main/java/org/alpha/omega/hogwarts_artifacts_online/artifact/controller/ArtifactController.java
+++ b/src/main/java/org/alpha/omega/hogwarts_artifacts_online/artifact/controller/ArtifactController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping(path = "/api/v1/artifacts")
+@RequestMapping(path = "${api.endpoint.base-url.v1}/artifacts")
 @RequiredArgsConstructor
 public class ArtifactController {
 

--- a/src/main/java/org/alpha/omega/hogwarts_artifacts_online/artifact/service/ArtifactService.java
+++ b/src/main/java/org/alpha/omega/hogwarts_artifacts_online/artifact/service/ArtifactService.java
@@ -23,7 +23,7 @@ public class ArtifactService {
     public Artifact findById(String id) {
         return this.repository.findById(id)
                 .orElseThrow(() -> new NotFoundException(
-                        String.format(Constant.CustomExMessage.Artifact.NOT_FOUNT_ARTIFACT, id)));
+                        String.format(Constant.CustomExMessage.NOT_FOUND_OBJECT, Constant.ARTIFACT, id)));
     }
 
     public List<Artifact> findAll() {
@@ -45,13 +45,13 @@ public class ArtifactService {
                     return this.repository.save(artifactToUpdate);
                 }).orElseThrow(() ->
                     new NotFoundException(
-                            String.format(Constant.CustomExMessage.Artifact.NOT_FOUNT_ARTIFACT, artifactId)));
+                            String.format(Constant.CustomExMessage.NOT_FOUND_OBJECT, Constant.ARTIFACT, artifactId)));
     }
 
     public void delete(String artifactId) {
         Artifact artifactToDelete = this.repository.findById(artifactId)
                 .orElseThrow(() -> new NotFoundException(
-                        String.format(Constant.CustomExMessage.Artifact.NOT_FOUNT_ARTIFACT, artifactId)));
+                        String.format(Constant.CustomExMessage.NOT_FOUND_OBJECT, Constant.ARTIFACT, artifactId)));
         this.repository.delete(artifactToDelete);
     }
 }

--- a/src/main/java/org/alpha/omega/hogwarts_artifacts_online/common/Constant.java
+++ b/src/main/java/org/alpha/omega/hogwarts_artifacts_online/common/Constant.java
@@ -4,24 +4,14 @@ public class Constant {
 
     private Constant() {}
 
+    public static final String ARTIFACT = "artifact";
+    public static final String WIZARD = "wizard";
+
     public static class CustomExMessage {
 
         private CustomExMessage() {}
 
         public static final String INVALID_ARGUMENTS = "Provided arguments are invalid, see data for details.";
-
-        public static class Artifact {
-
-            private Artifact() {}
-
-            public static final String NOT_FOUNT_ARTIFACT = "Could not find artifact with Id: %s";
-        }
-
-        public static class Wizard {
-
-            private Wizard() {}
-
-            public static final String NOT_FOUND_WIZARD = "Could not find wizard with Id: %s";
-        }
+        public static final String NOT_FOUND_OBJECT = "Could not find %s with Id: %s";
     }
 }

--- a/src/main/java/org/alpha/omega/hogwarts_artifacts_online/entity/Wizard.java
+++ b/src/main/java/org/alpha/omega/hogwarts_artifacts_online/entity/Wizard.java
@@ -24,7 +24,7 @@ public class Wizard  implements Serializable {
     @Column(name = "name", nullable = false, length = 80)
     private String name;
 
-    @OneToMany(mappedBy = "wizard", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
+    @OneToMany(mappedBy = "wizard", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private Set<Artifact> artifacts = new HashSet<>();
 
 
@@ -36,6 +36,11 @@ public class Wizard  implements Serializable {
     public void removeArtifact(Artifact artifact) {
         this.artifacts.remove(artifact);
         artifact.setWizard(null);
+    }
+
+    public void disassociateArtifactsRelated() {
+        if (this.artifacts != null)
+            this.artifacts.forEach(artifact -> artifact.setWizard(null));
     }
 
     public Integer getNumberOfArtifacts() {

--- a/src/main/java/org/alpha/omega/hogwarts_artifacts_online/wizard/controller/WizardController.java
+++ b/src/main/java/org/alpha/omega/hogwarts_artifacts_online/wizard/controller/WizardController.java
@@ -13,7 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping(path = "/api/v1/wizards")
+@RequestMapping(path = "${api.endpoint.base-url.v1}/wizards")
 @RequiredArgsConstructor
 public class WizardController {
 

--- a/src/main/java/org/alpha/omega/hogwarts_artifacts_online/wizard/service/WizardService.java
+++ b/src/main/java/org/alpha/omega/hogwarts_artifacts_online/wizard/service/WizardService.java
@@ -20,7 +20,7 @@ public class WizardService {
     public Wizard findById(Long wizardId) {
         return this.repository.findById(wizardId)
                 .orElseThrow(() -> new NotFoundException(
-                        String.format(Constant.CustomExMessage.Wizard.NOT_FOUND_WIZARD, wizardId)));
+                        String.format(Constant.CustomExMessage.NOT_FOUND_OBJECT, Constant.WIZARD, wizardId)));
     }
 
     public List<Wizard> findAll() {
@@ -38,13 +38,14 @@ public class WizardService {
                             wizardToUpdate.setName(updatedWizard.getName());
                             return this.repository.save(wizardToUpdate);
                         }).orElseThrow(() -> new NotFoundException(
-                            String.format(Constant.CustomExMessage.Wizard.NOT_FOUND_WIZARD, wizardId)));
+                            String.format(Constant.CustomExMessage.NOT_FOUND_OBJECT, Constant.WIZARD, wizardId)));
     }
 
     public void deleteWizard(Long id) {
         Wizard wizardToDelete = this.repository.findById(id)
                 .orElseThrow(() -> new NotFoundException(
-                        String.format(Constant.CustomExMessage.Wizard.NOT_FOUND_WIZARD, id)));
+                        String.format(Constant.CustomExMessage.NOT_FOUND_OBJECT, Constant.WIZARD, id)));
+        wizardToDelete.disassociateArtifactsRelated();
         this.repository.delete(wizardToDelete);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,7 @@ spring:
     driver-class-name: org.h2.Driver
   jpa:
     show-sql: true
+api:
+  endpoint:
+    base-url:
+      v1: /api/v1

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/artifact/service/ArtifactServiceTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/artifact/service/ArtifactServiceTest.java
@@ -93,7 +93,7 @@ class ArtifactServiceTest {
 
         // Then.
         assertThat(thrown).isInstanceOf(NotFoundException.class)
-                .hasMessage(String.format(TestConstant.Exception.Artifact.NOT_FOUNT_ARTIFACT, TestConstant.ARTIFACT_ID));
+                .hasMessage(String.format(TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.ARTIFACT, TestConstant.ARTIFACT_ID));
         verify(this.repository, times(1)).findById(TestConstant.ARTIFACT_ID);
     }
 
@@ -167,7 +167,7 @@ class ArtifactServiceTest {
 
         // Then
         assertThat(thrown).isInstanceOf(NotFoundException.class)
-                .hasMessage(String.format(TestConstant.Exception.Artifact.NOT_FOUNT_ARTIFACT, TestConstant.ARTIFACT_ID));
+                .hasMessage(String.format(TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.ARTIFACT, TestConstant.ARTIFACT_ID));
         verify(this.repository, times(1)).findById(TestConstant.ARTIFACT_ID);
     }
 

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/common/constant/TestConstant.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/common/constant/TestConstant.java
@@ -7,25 +7,14 @@ public class TestConstant {
 
     public static final String ARTIFACT_ID = "10435344876";
     public static final Long WIZARD_ID = 1L;
+    public static final String ARTIFACT = "artifact";
+    public static final String WIZARD = "wizard";
 
     public static class Exception {
 
         private Exception() {}
 
         public static final Object INVALID_ARGUMENTS = "Provided arguments are invalid, see data for details.";
-
-        public static class Artifact {
-
-            private Artifact() {}
-
-            public static final String NOT_FOUNT_ARTIFACT = "Could not find artifact with Id: %s";
-        }
-
-        public static class Wizard {
-
-            private Wizard() {}
-
-            public static final String NOT_FOUND_WIZARD = "Could not find wizard with Id: %s";
-        }
+        public static final String NOT_FOUND_OBJECT = "Could not find %s with Id: %s";
     }
 }

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/wizard/controller/WizardControllerTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/wizard/controller/WizardControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
@@ -40,6 +41,9 @@ class WizardControllerTest {
     @MockitoBean
     private WizardService service;
 
+    @Value(value = "${api.endpoint.base-url.v1}")
+    private String baseUrl;
+
     @Autowired
     ObjectMapper mapper;
 
@@ -58,7 +62,7 @@ class WizardControllerTest {
         given(this.service.findById(TestConstant.WIZARD_ID)).willReturn(wizardToReturn);
 
         // When and Then
-        this.mockMvc.perform(get("/api/v1/wizards/{wizardId}", TestConstant.WIZARD_ID))
+        this.mockMvc.perform(get(this.baseUrl + "/wizards/{wizardId}", TestConstant.WIZARD_ID))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
                 .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
@@ -73,15 +77,15 @@ class WizardControllerTest {
         // Given
         given(this.service.findById(TestConstant.WIZARD_ID))
                 .willThrow(new NotFoundException(
-                        String.format(Constant.CustomExMessage.Wizard.NOT_FOUND_WIZARD, TestConstant.WIZARD_ID)));
+                        String.format(TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.WIZARD, TestConstant.WIZARD_ID)));
 
         // When and Then
-        this.mockMvc.perform(get("/api/v1/wizards/{wizardId}", TestConstant.WIZARD_ID))
+        this.mockMvc.perform(get(this.baseUrl + "/wizards/{wizardId}", TestConstant.WIZARD_ID))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
                 .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
                 .andExpect(jsonPath("$.message").value(String.format(
-                        Constant.CustomExMessage.Wizard.NOT_FOUND_WIZARD, TestConstant.WIZARD_ID)));
+                        TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.WIZARD, TestConstant.WIZARD_ID)));
     }
 
     @Test
@@ -90,7 +94,7 @@ class WizardControllerTest {
         given(this.service.findAll()).willReturn(this.wizards);
 
         // When and Then
-        this.mockMvc.perform(get("/api/v1/wizards"))
+        this.mockMvc.perform(get(this.baseUrl + "/wizards"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
                 .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
@@ -107,7 +111,7 @@ class WizardControllerTest {
         given(this.service.findAll()).willReturn(Collections.emptyList());
 
         // When and Then
-        this.mockMvc.perform(get("/api/v1/wizards"))
+        this.mockMvc.perform(get(this.baseUrl + "/wizards"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
                 .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
@@ -130,7 +134,7 @@ class WizardControllerTest {
         given(this.service.createWizard(Mockito.any(Wizard.class))).willReturn(createdWizard);
 
         // When and Then
-        this.mockMvc.perform(post("/api/v1/wizards")
+        this.mockMvc.perform(post(this.baseUrl + "/wizards")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json)
                         .accept(MediaType.APPLICATION_JSON))
@@ -150,7 +154,7 @@ class WizardControllerTest {
         String json = this.mapper.writeValueAsString(request);
 
         // When and Then
-        this.mockMvc.perform(post("/api/v1/wizards")
+        this.mockMvc.perform(post(this.baseUrl + "/wizards")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json)
                         .accept(MediaType.APPLICATION_JSON))
@@ -176,7 +180,7 @@ class WizardControllerTest {
         given(this.service.updateWizard(updatedWizard)).willReturn(updatedWizard);
 
         // When and Then
-        this.mockMvc.perform(put("/api/v1/wizards/{wizardId}", TestConstant.WIZARD_ID)
+        this.mockMvc.perform(put(this.baseUrl + "/wizards/{wizardId}", TestConstant.WIZARD_ID)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(json)
                             .accept(MediaType.APPLICATION_JSON))
@@ -196,7 +200,7 @@ class WizardControllerTest {
         String json = this.mapper.writeValueAsString(request);
 
         // When and Then
-        this.mockMvc.perform(put("/api/v1/wizards/{wizardId}", TestConstant.WIZARD_ID)
+        this.mockMvc.perform(put(this.baseUrl + "/wizards/{wizardId}", TestConstant.WIZARD_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json)
                         .accept(MediaType.APPLICATION_JSON))
@@ -214,7 +218,7 @@ class WizardControllerTest {
         doNothing().when(this.service).deleteWizard(TestConstant.WIZARD_ID);
 
         // When and Then
-        this.mockMvc.perform(delete("/api/v1/wizards/{wizardId}", TestConstant.WIZARD_ID))
+        this.mockMvc.perform(delete(this.baseUrl + "/wizards/{wizardId}", TestConstant.WIZARD_ID))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
                 .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
@@ -226,16 +230,16 @@ class WizardControllerTest {
     void testDeleteWizardByIdNotFound() throws Exception {
         // Given
         doThrow(new NotFoundException(
-                String.format(TestConstant.Exception.Wizard.NOT_FOUND_WIZARD, TestConstant.WIZARD_ID)))
+                String.format(TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.WIZARD, TestConstant.WIZARD_ID)))
                 .when(this.service).deleteWizard(TestConstant.WIZARD_ID);
 
         // When and Then
-        this.mockMvc.perform(delete("/api/v1/wizards/{wizardId}", TestConstant.WIZARD_ID))
+        this.mockMvc.perform(delete(this.baseUrl + "/wizards/{wizardId}", TestConstant.WIZARD_ID))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
                 .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
                 .andExpect(jsonPath("$.message").value(
-                        String.format(TestConstant.Exception.Wizard.NOT_FOUND_WIZARD, TestConstant.WIZARD_ID)))
+                        String.format(TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.WIZARD, TestConstant.WIZARD_ID)))
                 .andExpect(jsonPath("$.data").isEmpty());
     }
 }


### PR DESCRIPTION
- Was delete the attribute: orphanRemoval = true of the field artifacts in the Wizard class, for avoid deleting artifacts associated to wizard.
- Was add the method: "disassociateArtifactsRelated" for desassociated the artifacts associated to wizard to delete in service layer
- The before method was invoked in the service before of delete a wizard.