### PR TITLE
Implement integrations test for: artifact, wizard and user API endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,13 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
 		</dependency>
+
+		<!-- used for pass user and password in login and get token -->
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/alpha/omega/hogwarts_artifacts_online/common/system/DBDataInitializer.java
+++ b/src/main/java/org/alpha/omega/hogwarts_artifacts_online/common/system/DBDataInitializer.java
@@ -11,9 +11,11 @@ import org.alpha.omega.hogwarts_artifacts_online.user.service.UserService;
 import org.alpha.omega.hogwarts_artifacts_online.wizard.repository.WizardRepository;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Set;
 
 @Component
 public class DBDataInitializer implements CommandLineRunner {
@@ -31,6 +33,7 @@ public class DBDataInitializer implements CommandLineRunner {
     }
 
 
+    @Transactional
     @Override
     public void run(String... args) throws Exception {
         Artifact firstArtifact = Artifact.builder()
@@ -90,24 +93,6 @@ public class DBDataInitializer implements CommandLineRunner {
                 .build();
         thirdWizard.addArtifact(fifthArtifact);
 
-        this.userService.saveUser(User.builder()
-                .username("admin")
-                .password("$$SadracFul21")
-                .enabled(Boolean.TRUE)
-                .build());
-
-        this.userService.saveUser(User.builder()
-                .username("sfulgencio")
-                .password("$$StivetFul2184$$")
-                .enabled(Boolean.TRUE)
-                .build());
-
-        this.userService.saveUser(User.builder()
-                .username("jarce")
-                .password("$#jdarce#$")
-                .enabled(Boolean.FALSE)
-                .build());
-
         Role adminRole = Role.builder()
                 .name(UserRole.ADMIN.name())
                 .build();
@@ -119,9 +104,30 @@ public class DBDataInitializer implements CommandLineRunner {
         Role sysAdminRole = Role.builder()
                 .name(UserRole.SYS_ADMIN.name())
                 .build();
+        this.roleRepository.saveAll(Arrays.asList(adminRole, userRole, sysAdminRole));
+
+        this.userService.saveUser(User.builder()
+                .username("admin")
+                .password("$$SadracFul21")
+                .enabled(Boolean.TRUE)
+                .userRoles(Set.of(adminRole))
+                .build());
+
+        this.userService.saveUser(User.builder()
+                .username("sfulgencio")
+                .password("$$StivetFul2184$$")
+                .enabled(Boolean.TRUE)
+                .userRoles(Set.of(sysAdminRole, userRole))
+                .build());
+
+        this.userService.saveUser(User.builder()
+                .username("jarce")
+                .password("$#jdarce#$")
+                .enabled(Boolean.FALSE)
+                .userRoles(Set.of(userRole))
+                .build());
 
         this.wizardRepository.saveAll(Arrays.asList(firstWizard, secondWizard, thirdWizard));
         this.artifactRepository.save(sixthArtifact);
-        this.roleRepository.saveAll(Arrays.asList(adminRole, userRole, sysAdminRole));
     }
 }

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/artifact/controller/ArtifactControllerIntegrationTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/artifact/controller/ArtifactControllerIntegrationTest.java
@@ -1,0 +1,236 @@
+package org.alpha.omega.hogwarts_artifacts_online.artifact.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.alpha.omega.hogwarts_artifacts_online.artifact.request.ArtifactRequest;
+import org.alpha.omega.hogwarts_artifacts_online.common.constant.TestConstant;
+import org.hamcrest.Matchers;
+import org.json.JSONObject;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestMethodOrder(value = MethodOrderer.OrderAnnotation.class)
+/* The next annotations are optionals */
+@DisplayName(value = "Integration tests for Artifacts API endpoints.")
+@Tag(value = "integration")
+/* Integration tests when Spring Security is turn on */
+/* Integration test, as the name suggest, be in focus on integrate different layers of application.
+* We are testing of integrate spring boot application from end to end, there is, from controller, the repository and database.
+* Also mean, not mocking is equals, will around integration test against testing data store in each to database  */
+class ArtifactControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private String token;
+
+    @Value(value = "${api.endpoint.base-url.v1}")
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        ResultActions resultActions = this.mockMvc.perform(post(this.baseUrl + "/users/login")
+                .with(httpBasic(TestConstant.Security.USER_ADMIN, TestConstant.Security.USER_ADMIN_PASSWORD)));
+        MvcResult mvcResult = resultActions.andDo(print()).andReturn();
+        String contentAsString = mvcResult.getResponse().getContentAsString();
+        JSONObject json = new JSONObject(contentAsString);
+        this.token = TestConstant.Security.AuthType.BEARER + json.getJSONObject("data").getString("token"); // Don't forget to add "Bearer " as a prefix
+    }
+
+    @Test
+    @Order(value = 1)
+    void testFindArtifactById() throws Exception {
+        this.mockMvc.perform(get(this.baseUrl + "/artifacts/{artifactId}", TestConstant.ARTIFACT_ID)
+                                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Find One Success"))
+                .andExpect(jsonPath("$.data.id").value(TestConstant.ARTIFACT_ID))
+                .andExpect(jsonPath("$.data.name").value("Deluminator"))
+                .andExpect(jsonPath("$.data.description").value("A deluminator is a device invented by Albus "))
+                .andExpect(jsonPath("$.data.imageUrl").value("first imageUrl"));
+    }
+
+    @Test
+    @Order(value = 2)
+    void testFindArtifactByIdNotFound() throws Exception {
+        this.mockMvc.perform(get(this.baseUrl + "/artifacts/{artifactId}", TestConstant.ARTIFACT_ID + "7")
+                            .accept(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.message").value(String
+                        .format(TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.ARTIFACT,
+                                TestConstant.ID, TestConstant.ARTIFACT_ID + "7")))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @Order(value = 3)
+    //@DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+    void testFindAllArtifacts() throws Exception {
+        this.mockMvc.perform(get(this.baseUrl + "/artifacts")
+                                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Find One Success"))
+                .andExpect(jsonPath("$.data", Matchers.hasSize(6)));
+    }
+
+    @Test
+    @Order(value = 4)
+    @DisplayName(value = "Check add artifact with valid input (POST)")
+    void testAddArtifact() throws Exception {
+        ArtifactRequest request = ArtifactRequest.builder()
+                                .name("Artifact 3")
+                                .description("Description...!!")
+                                .imageUrl("imageUrl...!!")
+                                .build();
+        String json = this.objectMapper.writeValueAsString(request);
+
+        this.mockMvc.perform(post(this.baseUrl + "/artifacts")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .content(json)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.CREATED.value()))
+                .andExpect(jsonPath("$.message").value("Add Success"))
+                .andExpect(jsonPath("$.data.id").isNotEmpty())
+                .andExpect(jsonPath("$.data.name").value(request.name()))
+                .andExpect(jsonPath("$.data.description").value(request.description()))
+                .andExpect(jsonPath("$.data.imageUrl").value(request.imageUrl()));
+
+        this.mockMvc.perform(get(this.baseUrl + "/artifacts")
+                            .accept(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Find One Success"))
+                .andExpect(jsonPath("$.data").isNotEmpty())
+                .andExpect(jsonPath("$.data", Matchers.hasSize(7)));
+    }
+
+    @Test
+    @Order(value = 5)
+    void testAddArtifactBadRequest() throws Exception {
+        ArtifactRequest request = ArtifactRequest.builder()
+                .description("Description...!!")
+                .imageUrl("imageUrl...!!")
+                .build();
+        String json = this.objectMapper.writeValueAsString(request);
+
+        this.mockMvc.perform(post(this.baseUrl + "/artifacts")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .content(json)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.message").value(TestConstant.Exception.INVALID_ARGUMENTS))
+                .andExpect(jsonPath("$.data").isNotEmpty())
+                .andExpect(jsonPath("$.data").isArray());
+    }
+
+    @Test
+    @Order(value = 6)
+    void testUpdateArtifact() throws Exception {
+        ArtifactRequest request = ArtifactRequest.builder()
+                .name("updated name.")
+                .description("updated description.")
+                .imageUrl("updated image url.")
+                .build();
+        String json = this.objectMapper.writeValueAsString(request);
+
+        this.mockMvc.perform(put(this.baseUrl + "/artifacts/{artifactId}", TestConstant.ARTIFACT_ID)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .header("Authorization", this.token)
+                                .content(json)
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Update Success"))
+                .andExpect(jsonPath("$.data").isNotEmpty())
+                .andExpect(jsonPath("$.data.id").value(TestConstant.ARTIFACT_ID))
+                .andExpect(jsonPath("$.data.name").value(request.name()))
+                .andExpect(jsonPath("$.data.description").value(request.description()))
+                .andExpect(jsonPath("$.data.imageUrl").value(request.imageUrl()));
+    }
+
+    @Test
+    @Order(value = 7)
+    void testUpdateArtifactBadRequest() throws Exception {
+        ArtifactRequest request = ArtifactRequest.builder()
+                .description("updated description.")
+                .imageUrl("updated image url.")
+                .build();
+        String json = this.objectMapper.writeValueAsString(request);
+
+        this.mockMvc.perform(put(this.baseUrl + "/artifacts/{artifactId}", TestConstant.ARTIFACT_ID)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .content(json)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.message").value(TestConstant.Exception.INVALID_ARGUMENTS))
+                .andExpect(jsonPath("$.data").isNotEmpty())
+                .andExpect(jsonPath("$.data").isArray());
+    }
+
+    @Test
+    @Order(value = 8)
+    void testDeleteArtifactById() throws Exception {
+        this.mockMvc.perform(delete(this.baseUrl + "/artifacts/{artifactId}", TestConstant.ARTIFACT_ID)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Delete Success"));
+
+        this.mockMvc.perform(get(this.baseUrl + "/artifacts")
+                            .accept(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Find One Success"))
+                .andExpect(jsonPath("$.data", Matchers.hasSize(6)));
+    }
+
+    @Test
+    @Order(value = 9)
+    void testDeleteArtifactByIdNotFound() throws Exception {
+        this.mockMvc.perform(delete(this.baseUrl + "/artifacts/{artifactId}", TestConstant.ARTIFACT_ID + "7")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header("Authorization", this.token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.message").value(String.format(
+                        TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.ARTIFACT,
+                        TestConstant.ID, TestConstant.ARTIFACT_ID + "7")));
+
+        this.mockMvc.perform(get(this.baseUrl + "/artifacts")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Find One Success"))
+                .andExpect(jsonPath("$.data", Matchers.hasSize(6)));
+    }
+}

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/artifact/controller/ArtifactControllerTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/artifact/controller/ArtifactControllerTest.java
@@ -32,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)// Turn off Spring Security. This is controller unit tests
 class ArtifactControllerTest {
 
     @Autowired

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/common/constant/TestConstant.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/common/constant/TestConstant.java
@@ -4,13 +4,14 @@ public class TestConstant {
 
     private TestConstant() {}
 
-    public static final String ARTIFACT_ID = "10435344876";
+    public static final String ARTIFACT_ID = "425344871";
     public static final Long WIZARD_ID = 1L;
     public static final Integer USER_ID = 1;
     public static final String ARTIFACT = "artifact";
     public static final String WIZARD = "wizard";
     public static final String USER = "user";
     public static final String ID = "Id";
+    public static final String ENCODED_PASSWORD = "encoded password";
 
     public static class Exception {
 
@@ -19,5 +20,20 @@ public class TestConstant {
         public static final Object INVALID_ARGUMENTS = "Provided arguments are invalid, see data for details.";
         public static final String NOT_FOUND_OBJECT = "Could not find %s with %s: %s";
         public static final String ALREADY_REGISTERED_OBJECT = "The %s with %s already registered.";
+    }
+
+    public static class Security {
+
+        private Security() {}
+
+        public static final String USER_ADMIN = "admin";
+        public static final String USER_ADMIN_PASSWORD = "$$SadracFul21";
+
+        public static class AuthType {
+
+            private AuthType() {}
+
+            public static final String BEARER = "Bearer ";
+        }
     }
 }

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/user/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/user/controller/UserControllerIntegrationTest.java
@@ -1,0 +1,278 @@
+package org.alpha.omega.hogwarts_artifacts_online.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.alpha.omega.hogwarts_artifacts_online.common.constant.TestConstant;
+import org.alpha.omega.hogwarts_artifacts_online.user.request.UserRequest;
+import org.alpha.omega.hogwarts_artifacts_online.user.request.UserRequestUpdt;
+import org.hamcrest.Matchers;
+import org.json.JSONObject;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestMethodOrder(value = MethodOrderer.OrderAnnotation.class)
+/* The next annotations are optionals */
+@DisplayName(value = "Integration tests for User API endpoints.")
+@Tag(value = "integration")
+class UserControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Value(value = "${api.endpoint.base-url.v1}")
+    private String baseUrl;
+
+    private String token;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        ResultActions resultActions = this.mockMvc.perform(post(this.baseUrl + "/users/login")
+                        .with(httpBasic(TestConstant.Security.USER_ADMIN, TestConstant.Security.USER_ADMIN_PASSWORD)));
+        MvcResult mvcResult = resultActions.andDo(print()).andReturn();
+        String contentAsString = mvcResult.getResponse().getContentAsString();
+        JSONObject json = new JSONObject(contentAsString);
+        this.token = TestConstant.Security.AuthType.BEARER + json.getJSONObject("data").getString("token");
+    }
+
+    @Test
+    @Order(value = 1)
+    void testGetUserById() throws Exception {
+        this.mockMvc.perform(get(this.baseUrl + "/users/{userId}", TestConstant.USER_ID)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Find success"))
+                .andExpect(jsonPath("$.data").isNotEmpty())
+                .andExpect(jsonPath("$.data.id").value(TestConstant.USER_ID))
+                .andExpect(jsonPath("$.data.enabled").value(Boolean.TRUE));
+    }
+
+    @Test
+    @Order(value = 2)
+    void testGetUserByIdNotFound() throws Exception {
+        this.mockMvc.perform(get(this.baseUrl + "/users/{userId}", 111)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.message").value(
+                        String.format(TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.USER,
+                                TestConstant.ID, 111)))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @Order(value = 3)
+    void testGetAllUsers() throws Exception {
+        this.mockMvc.perform(get(this.baseUrl + "/users")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Find all Success."))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data", Matchers.hasSize(3)));
+    }
+
+    @Test
+    @Order(value = 4)
+    void testSaveNewUser() throws Exception {
+        UserRequest request = UserRequest.builder()
+                .enabled(Boolean.TRUE)
+                .username("ssfulgencio")
+                .password("$$SadracFul0121$$")
+                .build();
+        String json = this.objectMapper.writeValueAsString(request);
+
+        this.mockMvc.perform(post(this.baseUrl + "/users")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .content(json)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.CREATED.value()))
+                .andExpect(jsonPath("$.message").value("New user created."))
+                .andExpect(jsonPath("$.data.id").isNotEmpty())
+                .andExpect(jsonPath("$.data.enabled").value(request.enabled()))
+                .andExpect(jsonPath("$.data.username").value(request.username()));
+
+        this.mockMvc.perform(get(this.baseUrl + "/users")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Find all Success."))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data", Matchers.hasSize(4)));
+    }
+
+    @Test
+    @Order(value = 5)
+    void testSaveNewUserBadRequest() throws Exception {
+        UserRequest request = UserRequest.builder()
+                .enabled(Boolean.TRUE)
+                .password("$$SadracFul0121$$")
+                .build();
+        String json = this.objectMapper.writeValueAsString(request);
+
+        this.mockMvc.perform(post(this.baseUrl + "/users")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .content(json)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.message").value(TestConstant.Exception.INVALID_ARGUMENTS))
+                .andExpect(jsonPath("$.data").isArray());
+    }
+
+    @Test
+    @Order(value = 6)
+    void testSaveNewUserAlreadyRegistered() throws Exception {
+        UserRequest request = UserRequest.builder()
+                .enabled(Boolean.TRUE)
+                .username("sfulgencio")
+                .password("$$SadracFul0121$$")
+                .build();
+        String json = this.objectMapper.writeValueAsString(request);
+
+        this.mockMvc.perform(post(this.baseUrl + "/users")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .content(json)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.CONFLICT.value()))
+                .andExpect(jsonPath("$.message").value(String.format(
+                        TestConstant.Exception.ALREADY_REGISTERED_OBJECT, TestConstant.USER, request.username())))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @Order(value = 7)
+    void testUpdateUserByIdNotFound() throws Exception {
+        UserRequestUpdt request = UserRequestUpdt.builder()
+                .enabled(Boolean.FALSE)
+                .username("sys")
+                .build();
+        String json = this.objectMapper.writeValueAsString(request);
+
+        this.mockMvc.perform(put(this.baseUrl + "/users/{userId}", 111)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .content(json)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.message").value(String
+                        .format(TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.USER, TestConstant.ID, 111)))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @Order(value = 8)
+    void testUpdateUserById() throws Exception {
+        UserRequestUpdt request = UserRequestUpdt.builder()
+                .enabled(Boolean.TRUE)
+                .username("sys")
+                .build();
+        String json = this.objectMapper.writeValueAsString(request);
+
+        this.mockMvc.perform(put(this.baseUrl + "/users/{userId}", 3)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header("Authorization", this.token)
+                        .content(json)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("User updated successfully."))
+                .andExpect(jsonPath("$.data").isNotEmpty())
+                .andExpect(jsonPath("$.data.id").value(3))
+                .andExpect(jsonPath("$.data.enabled").value(request.enabled()))
+                .andExpect(jsonPath("$.data.username").value(request.username()));
+    }
+
+    @Test
+    @Order(value = 9)
+    void testUpdateUserByIdBadRequest() throws Exception {
+        UserRequestUpdt request = UserRequestUpdt.builder()
+                .enabled(Boolean.FALSE)
+                .build();
+        String json = this.objectMapper.writeValueAsString(request);
+
+        this.mockMvc.perform(put(this.baseUrl + "/users/{userId}", TestConstant.USER_ID)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header("Authorization", this.token)
+                        .content(json)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.message").value(TestConstant.Exception.INVALID_ARGUMENTS))
+                .andExpect(jsonPath("$.data").isArray());
+    }
+
+    @Test
+    @Order(value = 10)
+    void testDeleteUserByIdNotFound() throws Exception {
+        this.mockMvc.perform(delete(this.baseUrl + "/users/{userId}", 111)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header("Authorization", this.token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.message").value(String.format(
+                        TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.USER, TestConstant.ID, 111)))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @Order(value = 11)
+    void testDeleteUserById() throws Exception {
+        this.mockMvc.perform(delete(this.baseUrl + "/users/{userId}", TestConstant.USER_ID)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header("Authorization", this.token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("User deleted successfully"))
+                .andExpect(jsonPath("$.data").isEmpty());
+        this.mockMvc.perform(get(this.baseUrl + "/users")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header("Authorization", this.token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Find all Success."))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data", Matchers.hasSize(3)));
+    }
+}

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/user/controller/UserControllerTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/user/controller/UserControllerTest.java
@@ -33,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)// Turn off Spring Security. This is controller unit tests
 class UserControllerTest {
 
     @MockitoBean

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/user/service/UserServiceTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/user/service/UserServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,6 +29,9 @@ class UserServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @InjectMocks
     private UserService userService;
@@ -138,9 +142,10 @@ class UserServiceTest {
                 .id(TestConstant.USER_ID)
                 .enabled(Boolean.TRUE)
                 .username("sfulgencio")
-                .password("$$StivetFul2184$$")
+                .password(TestConstant.ENCODED_PASSWORD)
                 .build();
         given(this.userRepository.findByUsername(userToSave.getUsername())).willReturn(Optional.empty());
+        given(this.passwordEncoder.encode(userToSave.getPassword())).willReturn(TestConstant.ENCODED_PASSWORD);
         given(this.userRepository.save(userToSave)).willReturn(registeredUser);
 
         // When

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/wizard/controller/WizardControllerIntegrationTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/wizard/controller/WizardControllerIntegrationTest.java
@@ -1,0 +1,259 @@
+package org.alpha.omega.hogwarts_artifacts_online.wizard.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.alpha.omega.hogwarts_artifacts_online.common.constant.TestConstant;
+import org.alpha.omega.hogwarts_artifacts_online.wizard.request.WizardRequest;
+import org.hamcrest.Matchers;
+import org.json.JSONObject;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestMethodOrder(value = MethodOrderer.OrderAnnotation.class)
+/* The next annotations are optionals */
+@DisplayName(value = "Integration tests for Wizard API endpoints.")
+@Tag(value = "integration")
+class WizardControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Value(value = "${api.endpoint.base-url.v1}")
+    private String baseUrl;
+
+    private String token;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        ResultActions resultActions = this.mockMvc.perform(post(this.baseUrl + "/users/login")
+                        .with(httpBasic(TestConstant.Security.USER_ADMIN, TestConstant.Security.USER_ADMIN_PASSWORD)));
+        MvcResult mvcResult = resultActions.andDo(print()).andReturn();
+        String contentAsString = mvcResult.getResponse().getContentAsString();
+        JSONObject json = new JSONObject(contentAsString);
+        this.token = TestConstant.Security.AuthType.BEARER + json.getJSONObject("data").getString("token");
+    }
+
+    @Test
+    @Order(value = 1)
+    void testFindWizardById() throws Exception {
+        this.mockMvc.perform(get(this.baseUrl + "/wizards/{wizardId}", TestConstant.WIZARD_ID)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Find Success"))
+                .andExpect(jsonPath("$.data").isNotEmpty())
+                .andExpect(jsonPath("$.data.id").value(TestConstant.WIZARD_ID))
+                .andExpect(jsonPath("$.data.name").value("Albus Dumbledore"));
+    }
+
+    @Test
+    @Order(value = 2)
+    void testFindWizardByIdNotFound() throws Exception {
+        this.mockMvc.perform(get(this.baseUrl + "/wizards/{wizardId}", 110)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .header("Authorization", this.token)
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.message").value(String.format(
+                        TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.WIZARD, TestConstant.ID, 110)));
+    }
+
+    @Test
+    @Order(value = 3)
+    void testFindAllWizards() throws Exception {
+        this.mockMvc.perform(get(this.baseUrl + "/wizards")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Find all success"))
+                .andExpect(jsonPath("$.data").isNotEmpty())
+                .andExpect(jsonPath("$.data", Matchers.hasSize(3)));
+    }
+
+    @Test
+    @Order(value = 4)
+    void testCreateWizard() throws Exception {
+        WizardRequest request = WizardRequest.builder()
+                .name("Name of new Wizard.")
+                .build();
+        String json = this.objectMapper.writeValueAsString(request);
+
+        this.mockMvc.perform(post(this.baseUrl + "/wizards")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .content(json)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.CREATED.value()))
+                .andExpect(jsonPath("$.message").value("New wizard created successfully."))
+                .andExpect(jsonPath("$.data").isNotEmpty())
+                .andExpect(jsonPath("$.data.id").isNotEmpty());
+
+        this.mockMvc.perform(get(this.baseUrl + "/wizards")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Find all success"))
+                .andExpect(jsonPath("$.data", Matchers.hasSize(4)));
+    }
+
+    @Test
+    @Order(value = 5)
+    void testCreateWizardBadRequest() throws Exception {
+        WizardRequest request = WizardRequest.builder().build();
+        String json = this.objectMapper.writeValueAsString(request);
+
+        this.mockMvc.perform(post(this.baseUrl + "/wizards")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .content(json)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.message").value(TestConstant.Exception.INVALID_ARGUMENTS))
+                .andExpect(jsonPath("$.data").isNotEmpty());
+    }
+
+    @Test
+    @Order(value = 6)
+    void testUpdateWizardById() throws Exception {
+        WizardRequest request = WizardRequest.builder()
+                .name("New name for Wizard.")
+                .build();
+        String json = this.objectMapper.writeValueAsString(request);
+
+        this.mockMvc.perform(put(this.baseUrl + "/wizards/{wizardId}", TestConstant.WIZARD_ID)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .content(json)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Wizard updated successfully."))
+                .andExpect(jsonPath("$.data").isNotEmpty())
+                .andExpect(jsonPath("$.data.id").value(TestConstant.WIZARD_ID))
+                .andExpect(jsonPath("$.data.name").value(request.name()));
+    }
+
+    @Test
+    @Order(value = 7)
+    void testUpdateWizardIdBadRequest() throws Exception {
+        WizardRequest request = WizardRequest.builder().build();
+        String json = this.objectMapper.writeValueAsString(request);
+
+        this.mockMvc.perform(put(this.baseUrl + "/wizards/{wizardId}", TestConstant.WIZARD_ID)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .content(json)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.message").value(TestConstant.Exception.INVALID_ARGUMENTS))
+                .andExpect(jsonPath("$.data").isNotEmpty());
+    }
+
+    @Test
+    @Order(value = 8)
+    void testDeleteWizardById() throws Exception {
+        this.mockMvc.perform(delete(this.baseUrl + "/wizards/{wizardId}", TestConstant.WIZARD_ID)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Wizard delete successfully."))
+                .andExpect(jsonPath("$.data").isEmpty());
+
+        this.mockMvc.perform(get(this.baseUrl + "/wizards")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Find all success"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data", Matchers.hasSize(3)));
+    }
+
+    @Test
+    @Order(value = 9)
+    void testDeleteWizardByIdNotFound() throws Exception {
+        this.mockMvc.perform(delete(this.baseUrl + "/wizards/{wizardId}", 111L)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Authorization", this.token)
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.message").value(
+                        String.format(TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.WIZARD,
+                                TestConstant.ID, 111L)))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @Order(value = 10)
+    void testAssignArtifactToWizard() throws Exception {
+        this.mockMvc.perform(patch(this.baseUrl + "/wizards/{wizardId}/artifacts/{artifactId}", 3L, TestConstant.ARTIFACT_ID)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .header("Authorization", this.token)
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.TRUE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value("Artifact Assignment Success"))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @Order(value = 11)
+    void testAssignArtifactToWizardNotFoundArtifact() throws Exception {
+        this.mockMvc.perform(patch(this.baseUrl + "/wizards/{wizardId}/artifacts/{artifactId}",
+                        TestConstant.WIZARD_ID, TestConstant.ARTIFACT_ID + "7")
+                                .accept(MediaType.APPLICATION_JSON)
+                                .header("Authorization", this.token)
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.message").value(String.format(
+                        TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.ARTIFACT,
+                        TestConstant.ID, TestConstant.ARTIFACT_ID + "7")))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @Order(value = 12)
+    void testAssignArtifactToWizardNotFoundWizard() throws Exception {
+        this.mockMvc.perform(patch(this.baseUrl + "/wizards/{wizardId}/artifacts/{artifactId}",
+                        111L, TestConstant.ARTIFACT_ID)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header("Authorization", this.token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(Boolean.FALSE))
+                .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.message").value(String.format(
+                        TestConstant.Exception.NOT_FOUND_OBJECT, TestConstant.WIZARD, TestConstant.ID, 111L)))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+}

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/wizard/controller/WizardControllerTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/wizard/controller/WizardControllerTest.java
@@ -31,7 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)// Turn off Spring Security. This is controller unit tests
 class WizardControllerTest {
 
     @Autowired


### PR DESCRIPTION
- Add spring-security-test Maven dependency for pass user and password at login through method: "httpBasic" and get token used in integration test cases.
- Save roles before that the users, for asign these at the correspondly users and using transaction annotation over the run method for fix the error: InvalidDataAccessApiUsageException: detached entity passed to persist.
- Add integration test for API endpoints: Artifacts, Wizards and Users.
- Using annotation AutoConfigureMockMvc and its parameter addFilters set at false for turn off Spring Security in controllers unit tests: Artifacts, Wizards and Users.
- Add security and auth type constants for integration tests.
- Mock PasswordEncoder in the test save user for encode password in user service test.