### PR TITLE
Fix warnings and errors in at run tests at packaging the application

### DIFF
--- a/src/main/java/org/alpha/omega/hogwarts_artifacts_online/artifact/mapper/ArtifactMapper.java
+++ b/src/main/java/org/alpha/omega/hogwarts_artifacts_online/artifact/mapper/ArtifactMapper.java
@@ -6,6 +6,7 @@ import org.alpha.omega.hogwarts_artifacts_online.response.dto.ArtifactDTO;
 import org.alpha.omega.hogwarts_artifacts_online.wizard.mapper.WizardMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
 import org.mapstruct.factory.Mappers;
 
 import java.util.List;
@@ -20,5 +21,9 @@ public interface ArtifactMapper {
 
     List<ArtifactDTO> toArtifactsDTOs(List<Artifact> artifacts);
 
+    @Mappings(value = {
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "wizard", ignore = true)
+    })
     Artifact toArtifact(ArtifactRequest request);
 }

--- a/src/main/java/org/alpha/omega/hogwarts_artifacts_online/entity/Role.java
+++ b/src/main/java/org/alpha/omega/hogwarts_artifacts_online/entity/Role.java
@@ -3,7 +3,6 @@ package org.alpha.omega.hogwarts_artifacts_online.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -24,7 +23,7 @@ public class Role {
     private String name;
 
     @ManyToMany(mappedBy = "userRoles")
-    private Set<User> users = new HashSet<>();
+    private Set<User> users;
 
     @Override
     public boolean equals(Object obj) {

--- a/src/main/java/org/alpha/omega/hogwarts_artifacts_online/entity/User.java
+++ b/src/main/java/org/alpha/omega/hogwarts_artifacts_online/entity/User.java
@@ -3,7 +3,6 @@ package org.alpha.omega.hogwarts_artifacts_online.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -33,7 +32,7 @@ public class User {
     @JoinTable(name = "user_role",
     joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false, foreignKey = @ForeignKey(name = "user_id_fk")),
     inverseJoinColumns = @JoinColumn(name = "role_id", referencedColumnName = "id", nullable = false, foreignKey = @ForeignKey(name = "role_id_fk")))
-    private Set<Role> userRoles = new HashSet<>();
+    private Set<Role> userRoles;
 
     public void addRole(Role newRole) {
         newRole.getUsers().add(this);

--- a/src/main/java/org/alpha/omega/hogwarts_artifacts_online/entity/Wizard.java
+++ b/src/main/java/org/alpha/omega/hogwarts_artifacts_online/entity/Wizard.java
@@ -25,7 +25,7 @@ public class Wizard  implements Serializable {
     private String name;
 
     @OneToMany(mappedBy = "wizard", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
-    private Set<Artifact> artifacts = new HashSet<>();
+    private Set<Artifact> artifacts;
 
 
     public void addArtifact(Artifact artifact) {

--- a/src/main/java/org/alpha/omega/hogwarts_artifacts_online/user/mapper/UserMapper.java
+++ b/src/main/java/org/alpha/omega/hogwarts_artifacts_online/user/mapper/UserMapper.java
@@ -7,6 +7,7 @@ import org.alpha.omega.hogwarts_artifacts_online.user.request.UserRequest;
 import org.alpha.omega.hogwarts_artifacts_online.user.request.UserRequestUpdt;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
 import org.mapstruct.factory.Mappers;
 
 import java.util.List;
@@ -21,7 +22,16 @@ public interface UserMapper {
 
     List<UserDTO> toUsersDTOs(List<User> users);
 
+    @Mappings(value = {
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "userRoles", ignore = true)
+    })
     User toUser(UserRequest request);
 
+    @Mappings(value = {
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "password", ignore = true),
+            @Mapping(target = "userRoles", ignore = true)
+    })
     User toUser(UserRequestUpdt request);
 }

--- a/src/main/java/org/alpha/omega/hogwarts_artifacts_online/wizard/mapper/WizardMapper.java
+++ b/src/main/java/org/alpha/omega/hogwarts_artifacts_online/wizard/mapper/WizardMapper.java
@@ -4,6 +4,8 @@ import org.alpha.omega.hogwarts_artifacts_online.entity.Wizard;
 import org.alpha.omega.hogwarts_artifacts_online.response.dto.WizardDTO;
 import org.alpha.omega.hogwarts_artifacts_online.wizard.request.WizardRequest;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
 import org.mapstruct.factory.Mappers;
 
 import java.util.List;
@@ -26,5 +28,9 @@ public interface WizardMapper {
 
     List<WizardDTO> toWizardsDTOs(List<Wizard> wizards);
 
+    @Mappings(value = {
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "artifacts", ignore = true)
+    })
     Wizard toWizard(WizardRequest request);
 }

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/ExecutionOrderTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/ExecutionOrderTest.java
@@ -1,0 +1,60 @@
+package org.alpha.omega.hogwarts_artifacts_online;
+
+import org.alpha.omega.hogwarts_artifacts_online.artifact.controller.ArtifactControllerIntegrationTest;
+import org.alpha.omega.hogwarts_artifacts_online.artifact.controller.ArtifactControllerTest;
+import org.alpha.omega.hogwarts_artifacts_online.artifact.service.ArtifactServiceTest;
+import org.alpha.omega.hogwarts_artifacts_online.user.controller.UserControllerIntegrationTest;
+import org.alpha.omega.hogwarts_artifacts_online.user.service.UserServiceTest;
+import org.alpha.omega.hogwarts_artifacts_online.wizard.controller.WizardControllerIntegrationTest;
+import org.alpha.omega.hogwarts_artifacts_online.wizard.controller.WizardControllerTest;
+import org.alpha.omega.hogwarts_artifacts_online.wizard.service.WizardServiceTest;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestClassOrder;
+
+/*
+* To skip running tests from base test classes make that base test class abstract and then
+* define a class as this where we're extends each abstract test class, as show here, and define there order of execution.
+* It’s useful when we want to have some explicit control over execution order or
+* need to run tests in a specific sequence.
+* */
+@TestClassOrder(value = ClassOrderer.OrderAnnotation.class)
+class ExecutionOrderTest {
+
+    @Nested
+    @Order(value = 1)
+    class ArtifactControllerIntegrationTests extends ArtifactControllerIntegrationTest {}
+
+    @Nested
+    @Order(value = 2)
+    class ArtifactControllerTests extends ArtifactControllerTest {}
+
+    @Nested
+    @Order(value = 3)
+    class ArtifactServiceTests extends ArtifactServiceTest {}
+
+    @Nested
+    @Order(value = 4)
+    class WizardControllerIntegrationTests extends WizardControllerIntegrationTest {}
+
+    @Nested
+    @Order(value = 5)
+    class WizardControllerTests extends WizardControllerTest {}
+
+    @Nested
+    @Order(value = 6)
+    class WizardServiceTests extends WizardServiceTest {}
+
+    @Nested
+    @Order(value = 7)
+    class UserControllerIntegrationTests extends UserControllerIntegrationTest {}
+
+    @Nested
+    @Order(value = 8)
+    class UserControllerTests extends ArtifactControllerTest {}
+
+    @Nested
+    @Order(value = 9)
+    class UserServiceTests extends UserServiceTest{}
+}

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/artifact/controller/ArtifactControllerIntegrationTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/artifact/controller/ArtifactControllerIntegrationTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -28,11 +29,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /* The next annotations are optionals */
 @DisplayName(value = "Integration tests for Artifacts API endpoints.")
 @Tag(value = "integration")
+@ActiveProfiles(value = "dev")
 /* Integration tests when Spring Security is turn on */
 /* Integration test, as the name suggest, be in focus on integrate different layers of application.
 * We are testing of integrate spring boot application from end to end, there is, from controller, the repository and database.
 * Also mean, not mocking is equals, will around integration test against testing data store in each to database  */
-class ArtifactControllerIntegrationTest {
+public abstract class ArtifactControllerIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/artifact/controller/ArtifactControllerTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/artifact/controller/ArtifactControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -33,7 +34,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)// Turn off Spring Security. This is controller unit tests
-class ArtifactControllerTest {
+@ActiveProfiles(value = "dev")
+public abstract class ArtifactControllerTest {
 
     @Autowired
     MockMvc mvc;

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/artifact/service/ArtifactServiceTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/artifact/service/ArtifactServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,7 +32,8 @@ import static org.mockito.Mockito.verify;
 
 
 @ExtendWith(value = MockitoExtension.class)
-class ArtifactServiceTest {
+@ActiveProfiles(value = "dev")
+public abstract class ArtifactServiceTest {
 
     @Mock
     ArtifactRepository repository;

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/user/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/user/controller/UserControllerIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -29,7 +30,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /* The next annotations are optionals */
 @DisplayName(value = "Integration tests for User API endpoints.")
 @Tag(value = "integration")
-class UserControllerIntegrationTest {
+@ActiveProfiles(value = "dev")
+public abstract class UserControllerIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/user/controller/UserControllerTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/user/controller/UserControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -34,7 +35,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)// Turn off Spring Security. This is controller unit tests
-class UserControllerTest {
+@ActiveProfiles(value = "dev")
+public abstract class UserControllerTest {
 
     @MockitoBean
     private UserService userService;

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/user/service/UserServiceTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/user/service/UserServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,7 +26,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(value = MockitoExtension.class)
-class UserServiceTest {
+@ActiveProfiles(value = "dev")
+public abstract class UserServiceTest {
 
     @Mock
     private UserRepository userRepository;

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/wizard/controller/WizardControllerIntegrationTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/wizard/controller/WizardControllerIntegrationTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -27,7 +28,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /* The next annotations are optionals */
 @DisplayName(value = "Integration tests for Wizard API endpoints.")
 @Tag(value = "integration")
-class WizardControllerIntegrationTest {
+@ActiveProfiles(value = "dev")
+public abstract class WizardControllerIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/wizard/controller/WizardControllerTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/wizard/controller/WizardControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -32,7 +33,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)// Turn off Spring Security. This is controller unit tests
-class WizardControllerTest {
+@ActiveProfiles(value = "dev")
+public abstract class WizardControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/org/alpha/omega/hogwarts_artifacts_online/wizard/service/WizardServiceTest.java
+++ b/src/test/java/org/alpha/omega/hogwarts_artifacts_online/wizard/service/WizardServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.*;
 
@@ -26,7 +27,8 @@ import static org.mockito.Mockito.verify;
 
 
 @ExtendWith(value = MockitoExtension.class)
-class WizardServiceTest {
+@ActiveProfiles(value = "dev")
+public abstract class WizardServiceTest {
 
     @Mock
     private WizardRepository wizardRepository;


### PR DESCRIPTION
- Ignore explity the fields not mapping to target class, in mapper classes, for avoid warnings at get jar file.
- Delete the allocated memory on the heap for the object lists in entities classes, for avoid warnings at get jar file.
- Convert the base test classes in abstract classes and define and an active profile for there.
- Create an Execution Order Test Class to have explicit control over execution order and run tests in a specific sequence.